### PR TITLE
Migrate navigation APIs for iOS 18 and Swift 6

### DIFF
--- a/SMART Planning/Screens/ChooseGoal/ChooseGoalView.swift
+++ b/SMART Planning/Screens/ChooseGoal/ChooseGoalView.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 struct ChooseGoalView: View {
-    @Environment(\.presentationMode) var presentationMode
     @EnvironmentObject var settings: ViewSelector
     
     @StateObject var viewModel = GoalViewModel()
@@ -16,7 +15,7 @@ struct ChooseGoalView: View {
     @Binding var launchedByMainScreen: Bool
     
     var body: some View {
-        NavigationView {
+        NavigationStack {
             GeometryReader { geo in
                 body(for: geo.size)
             }

--- a/SMART Planning/Screens/ChooseGoal/CreateGoalView/GoalView.swift
+++ b/SMART Planning/Screens/ChooseGoal/CreateGoalView/GoalView.swift
@@ -9,7 +9,6 @@
 import SwiftUI
 
 struct GoalView: View {
-    @Environment(\.presentationMode) var presentationMode
     @EnvironmentObject var viewModel: GoalViewModel
     
     var body: some View {

--- a/SMART Planning/Screens/DailyTasks/DailyTasksView.swift
+++ b/SMART Planning/Screens/DailyTasks/DailyTasksView.swift
@@ -13,7 +13,7 @@ struct DailyTasksView: View {
     
     
     var body: some View {
-        NavigationView {
+        NavigationStack {
             List {
                 Section(header: SectionHeader(title: "Today")) {
                     ForEach(vm.todayTasks) { task in

--- a/SMART Planning/Screens/GoalDetailView/GoalDetailView.swift
+++ b/SMART Planning/Screens/GoalDetailView/GoalDetailView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct GoalDetailView: View {
-    @Environment(\.presentationMode) var presentationMode
+    @Environment(\.dismiss) private var dismiss
     @EnvironmentObject var brain: GoalsManager
     @StateObject var viewModel: GoalDetailsViewModel
     @StateObject var editGoalViewModel = GoalViewModel()
@@ -18,7 +18,7 @@ struct GoalDetailView: View {
     }
     
     var body: some View {
-        NavigationView {
+        NavigationStack {
             GeometryReader { geo in
                 ScrollView(showsIndicators: false) {
                     VStack(alignment: .leading) {
@@ -62,7 +62,7 @@ struct GoalDetailView: View {
     
     
     func dismissView() {
-        presentationMode.wrappedValue.dismiss()
+        dismiss()
     }
     
     

--- a/SMART Planning/Screens/PerformanceView/PerformanceView.swift
+++ b/SMART Planning/Screens/PerformanceView/PerformanceView.swift
@@ -12,7 +12,7 @@ struct PerformanceView: View {
     @StateObject var viewModel = PerformanceViewModel()
     
     var body: some View {
-        NavigationView {
+        NavigationStack {
             ScrollView {
                 SegmentedControl(tab: $viewModel.currentTab, tabs: [.weekly, .monthly, .total])
                 if viewModel.currentTab != .total {

--- a/SMART Planning/Screens/Timeline/TimelineView.swift
+++ b/SMART Planning/Screens/Timeline/TimelineView.swift
@@ -13,7 +13,7 @@ struct TimelineView: View {
     @State var showAddGoalsView = false
     
     var body: some View {
-        NavigationView {
+        NavigationStack {
             GeometryReader { geo in
                 ScrollView(showsIndicators: false) {
                     VStack(alignment: .leading, spacing: 10) {
@@ -37,7 +37,6 @@ struct TimelineView: View {
                 }
             }
         }
-        .navigationViewStyle(StackNavigationViewStyle())
     }
     
     func addGoals() {

--- a/SMART Planning/UIComponents/Buttons/DismissButton.swift
+++ b/SMART Planning/UIComponents/Buttons/DismissButton.swift
@@ -8,13 +8,13 @@
 import SwiftUI
 
 struct DismissButton: View {
-    @Environment(\.presentationMode) var presentationMode
+    @Environment(\.dismiss) private var dismiss
     
     var body: some View {
         HStack {
             Spacer()
             Button {
-                presentationMode.wrappedValue.dismiss()
+                dismiss()
             } label: {
                 Image(systemName: "xmark")
                     .foregroundColor(Color(.label))

--- a/SMART Planning/Unitilies/Extensions/UIApplication + ext.swift
+++ b/SMART Planning/Unitilies/Extensions/UIApplication + ext.swift
@@ -9,7 +9,10 @@ import UIKit
 
 extension UIApplication {
     func addTapGestureRecognizer() {
-        guard let window = windows.first else { return }
+        guard
+            let windowScene = connectedScenes.first as? UIWindowScene,
+            let window = windowScene.windows.first
+        else { return }
         let tapGesture = UITapGestureRecognizer(target: window, action: #selector(UIView.endEditing))
         tapGesture.cancelsTouchesInView = false
         tapGesture.delegate = self


### PR DESCRIPTION
## Summary
- Replace deprecated NavigationView usage with NavigationStack
- Update view dismissal to use the modern dismiss environment value
- Switch tap recognizer setup to query UIWindowScene windows instead of deprecated UIApplication.windows

## Testing
- `swiftc 'SMART Planning'/SMARTPlanningApp.swift -parse-as-library` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68b4c7b0ba148322ac7b59ef42882111