### PR TITLE
Fix concurrency warnings

### DIFF
--- a/SMART Planning/Unitilies/Helper.swift
+++ b/SMART Planning/Unitilies/Helper.swift
@@ -59,8 +59,8 @@ enum Spacing: CGFloat {
 struct MeasurementUnit {
     let displayTitle: String
     let shortTitle: String
-    
-    static var measurementUnits = [MeasurementUnit(displayTitle: "pages", shortTitle: "p."),
+
+    static let measurementUnits: [MeasurementUnit] = [MeasurementUnit(displayTitle: "pages", shortTitle: "p."),
                                    MeasurementUnit(displayTitle: "times", shortTitle: "t."),
                                    MeasurementUnit(displayTitle: "minutes", shortTitle: "min."),
                                    MeasurementUnit(displayTitle: "hours", shortTitle: "h."),
@@ -76,6 +76,7 @@ struct MeasurementUnit {
                                    MeasurementUnit(displayTitle: "credits", shortTitle: "cr.")]
 }
 
+@MainActor
 enum DeviceTypes {
     enum ScreenSize {
         static let width         = UIScreen.main.bounds.size.width


### PR DESCRIPTION
## Summary
- convert measurementUnits to an immutable constant
- mark DeviceTypes as main-actor isolated to ensure safe global access

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68b4caa3eadc83229fdbcea3fe4163e0